### PR TITLE
Conserve repeating order of atoms in POSCAR

### DIFF
--- a/pychemia/code/vasp/poscar.py
+++ b/pychemia/code/vasp/poscar.py
@@ -101,7 +101,7 @@ def read_poscar(path='POSCAR'):
         return Structure(cell=newcell, symbols=symbols, reduced=pos, comment=comment)
 
 
-def write_poscar(structure, filepath='POSCAR', newformat=True, direct=True, comment=None):
+def write_poscar(structure, filepath='POSCAR', newformat=True, direct=True, comment=None, heterostructure=False):
     """
     Takes an structure from pychemia and save the file
     POSCAR for VASP.
@@ -113,7 +113,14 @@ def write_poscar(structure, filepath='POSCAR', newformat=True, direct=True, comm
     :param direct: (bool) If True, use reduced coordinates. If False, use cartesian coordinates (default: True)
     """
     comp = structure.get_composition()
-    species = get_species_list(structure)
+
+    # If heterostructure is true it will keep the repeating order found
+    # in the POSCAR. 
+    # Added by Uthpala on Apr 20th, 2020.
+    if heterostructure:
+        species = [i[0] for i in groupby(structure.symbols)]
+    else:
+        species = get_species_list(structure)
 
     ret = ''
     if comment is None:

--- a/pychemia/code/vasp/poscar.py
+++ b/pychemia/code/vasp/poscar.py
@@ -7,6 +7,7 @@ from re import findall
 from numpy import zeros, array, sum
 from pychemia import Structure
 from pychemia.utils.periodic import atomic_symbols
+from itertools import groupby
 
 """
 Routines to read and write POSCAR file
@@ -171,9 +172,16 @@ def get_species(path):
     return species
 
 
-def write_potcar(structure, filepath='POTCAR', pspdir='potpaw_PBE', options=None, pspfiles=None, basepsp=None):
+def write_potcar(structure, filepath='POTCAR', pspdir='potpaw_PBE', options=None, pspfiles=None, basepsp=None, heterostructure=False):
 
-    species = get_species_list(structure)
+    # If heterostructure is true it will keep the repeating order found
+    # in the POSCAR. 
+    # Added by Uthpala on Apr 20th, 2020.
+    if heterostructure:
+        species = [i[0] for i in groupby(structure.symbols)]
+    else:
+        species = get_species_list(structure)
+
     ret = ''
     if basepsp is not None:
         psppath = os.path.abspath(basepsp) + os.sep + pspdir

--- a/pychemia/code/vasp/poscar.py
+++ b/pychemia/code/vasp/poscar.py
@@ -119,10 +119,9 @@ def write_poscar(structure, filepath='POSCAR', newformat=True, direct=True, comm
     # Added by Uthpala on Apr 20th, 2020.
     if heterostructure:
         species = [i[0] for i in groupby(structure.symbols)]
-        species_count = {i:species.count(i) for i in species}
     else:
         species = get_species_list(structure)
-    species_count = {i:species.count(i) for i in species}    
+    species_count = [len(list(group)) for key, group in groupby(structure.symbols)]   
 
     ret = ''
     if comment is None:
@@ -139,9 +138,9 @@ def write_poscar(structure, filepath='POSCAR', newformat=True, direct=True, comm
         for i in species:
             ret += ' ' + i
         ret += '\n'
-    for i in species:
+    for icount, i in enumerate(species):
         if heterostructure:
-           ret += ' ' + str(int(comp.composition[i]/species_count[i])) 
+           ret += ' ' + str(species_count[icount]) 
         else:
             ret += ' ' + str(comp.composition[i])
     ret += '\n'

--- a/pychemia/code/vasp/poscar.py
+++ b/pychemia/code/vasp/poscar.py
@@ -119,8 +119,10 @@ def write_poscar(structure, filepath='POSCAR', newformat=True, direct=True, comm
     # Added by Uthpala on Apr 20th, 2020.
     if heterostructure:
         species = [i[0] for i in groupby(structure.symbols)]
+        species_count = {i:species.count(i) for i in species}
     else:
         species = get_species_list(structure)
+    species_count = {i:species.count(i) for i in species}    
 
     ret = ''
     if comment is None:
@@ -138,8 +140,12 @@ def write_poscar(structure, filepath='POSCAR', newformat=True, direct=True, comm
             ret += ' ' + i
         ret += '\n'
     for i in species:
-        ret += ' ' + str(comp.composition[i])
+        if heterostructure:
+           ret += ' ' + str(int(comp.composition[i]/species_count[i])) 
+        else:
+            ret += ' ' + str(comp.composition[i])
     ret += '\n'
+
     if direct:
         ret += 'Direct\n'
         for i in range(structure.natom):

--- a/pychemia/code/vasp/task/convergence.py
+++ b/pychemia/code/vasp/task/convergence.py
@@ -95,7 +95,7 @@ class Convergence:
 
 class ConvergenceCutOffEnergy(Task, Convergence):
     def __init__(self, structure, workdir='.', kpoints=None, executable='vasp', energy_tolerance=1E-3,
-                 increment_factor=0.2, initial_encut=1.3, pspdir='potpaw_PBE', psp_options=None, extra_vars=None):
+                 increment_factor=0.2, initial_encut=1.3, pspdir='potpaw_PBE', psp_options=None, extra_vars=None, heterostructure=False):
         
         self.structure = structure
         self.workdir = workdir
@@ -116,6 +116,12 @@ class ConvergenceCutOffEnergy(Task, Convergence):
             self.kpoints = kp
         else:
             self.kpoints = kpoints
+
+        # If heterostructure is true it will keep the repeating order found
+        # in the POSCAR. 
+        # Added by Uthpala on Apr 20th, 2020.
+        self.heterostructure = heterostructure
+
         Convergence.__init__(self, energy_tolerance)
         self.task_params = {'energy_tolerance': self.energy_tolerance, 'increment_factor': self.increment_factor,
                             'initial_encut': self.initial_encut}
@@ -125,7 +131,7 @@ class ConvergenceCutOffEnergy(Task, Convergence):
 
         self.started = True
         vj = VaspJob(workdir=self.workdir, executable=self.executable)
-        vj.initialize(structure=self.structure, kpoints=self.kpoints, pspdir=self.pspdir)
+        vj.initialize(structure=self.structure, kpoints=self.kpoints, pspdir=self.pspdir, heterostructure=self.heterostructure)
         vj.potcar_setup = self.psp_options
         energies = []
         if not self.is_converge:
@@ -231,7 +237,7 @@ class ConvergenceCutOffEnergy(Task, Convergence):
 
 class ConvergenceKPointGrid(Task, Convergence):
     def __init__(self, structure, workdir='.', executable='vasp', energy_tolerance=1E-3, recover=False, encut=1.3,
-                 pspdir='potpaw_PBE', extra_vars=None, psp_options=None):
+                 pspdir='potpaw_PBE', extra_vars=None, psp_options=None, heterostructure=False):
 
         self.structure = structure
         self.workdir = workdir
@@ -245,6 +251,12 @@ class ConvergenceKPointGrid(Task, Convergence):
             self.extra_vars = extra_vars
         else:
             self.extra_vars = {}
+
+        # If heterostructure is true it will keep the repeating order found
+        # in the POSCAR. 
+        # Added by Uthpala on Apr 20th, 2020.
+        self.heterostructure = heterostructure
+
         Convergence.__init__(self, energy_tolerance)
         if recover:
             self.recover()
@@ -267,7 +279,7 @@ class ConvergenceKPointGrid(Task, Convergence):
         vj = VaspJob(workdir=self.workdir, executable=self.executable)
         vj.potcar_setup = self.psp_options
         kp = KPoints()
-        vj.initialize(structure=self.structure, kpoints=kp, pspdir=self.pspdir)
+        vj.initialize(structure=self.structure, kpoints=kp, pspdir=self.pspdir, heterostructure=self.heterostructure)
         grid = None
         energies = []
         if not self.is_converge:

--- a/pychemia/code/vasp/task/relax.py
+++ b/pychemia/code/vasp/task/relax.py
@@ -23,10 +23,15 @@ __author__ = 'Guillermo Avendano-Franco'
 class IonRelaxation(Relaxator, Task):
     def __init__(self, structure, workdir='.', target_forces=1E-3, executable='vasp',
                  encut=1.3, kp_grid=None, kp_density=1E4, relax_cell=True,
-                 max_calls=10,pspdir='potpaw_PBE', psp_options=None, extra_vars=None):
+                 max_calls=10,pspdir='potpaw_PBE', psp_options=None, extra_vars=None, heterostructure=False):
 
         Relaxator.__init__(self, target_forces)
         self.target_forces = target_forces
+
+        # If heterostructure is true it will keep the repeating order found
+        # in the POSCAR. 
+        # Added by Uthpala on Apr 20th, 2020.
+        self.heterostructure = heterostructure 
 
         self.vaspjob = VaspJob(executable=executable, workdir=workdir)
         self.relaxed = False
@@ -34,7 +39,7 @@ class IonRelaxation(Relaxator, Task):
             self.kpoints = KPoints(kmode='gamma', grid=kp_grid)
         else:
             self.kpoints = KPoints.optimized_grid(structure.lattice, kp_density=kp_density)
-        self.vaspjob.initialize(structure=structure, kpoints=self.kpoints, pspdir=pspdir)
+        self.vaspjob.initialize(structure=structure, kpoints=self.kpoints, pspdir=pspdir, heterostructure=self.heterostructure)
         self.vaspjob.potcar_setup = psp_options
         self.encut = encut
         self.relax_cell = relax_cell
@@ -44,6 +49,9 @@ class IonRelaxation(Relaxator, Task):
             self.extra_vars = extra_vars
         else:
             self.extra_vars = {}
+
+        
+
         task_params = {'target_forces': self.target_forces, 'encut': self.encut, 'relax_cell': self.relax_cell,
                        'max_calls': self.max_calls}
         Task.__init__(self, structure=structure, task_params=task_params, workdir=workdir, executable=executable)

--- a/pychemia/code/vasp/vasp.py
+++ b/pychemia/code/vasp/vasp.py
@@ -47,7 +47,7 @@ class VaspJob(CodeRun):
         self._check_workdir()
         assert (isinstance(self.structure, Structure))
 
-        write_poscar(self.structure, filepath=self.workdir + os.sep + 'POSCAR')
+        write_poscar(self.structure, filepath=self.workdir + os.sep + 'POSCAR', heterostructure=self.heterostructure)
 
     def write_potcar(self):
 

--- a/pychemia/code/vasp/vasp.py
+++ b/pychemia/code/vasp/vasp.py
@@ -26,12 +26,14 @@ class VaspJob(CodeRun):
         self.poscar_setup = None
         self.stdout_file = None
         self.stdout_filename = 'vasp_stdout.log'
+        self.heterostructure = False
 
-    def initialize(self, structure, kpoints=None, pspdir='potpaw_PBE'):
+    def initialize(self, structure, kpoints=None, pspdir='potpaw_PBE', heterostructure=False):
         self.structure = structure
         self.set_kpoints(kpoints)
 
         self.potcar_pspdir = pspdir
+        self.heterostructure = heterostructure
 
     def _check_workdir(self):
 
@@ -53,7 +55,7 @@ class VaspJob(CodeRun):
         assert (isinstance(self.structure, Structure))
 
         pspfiles = write_potcar(self.structure, filepath=self.workdir + os.sep + 'POTCAR', pspdir=self.potcar_pspdir,
-                                options=self.potcar_setup, pspfiles=self.potcar_pspfiles)
+                                options=self.potcar_setup, pspfiles=self.potcar_pspfiles, heterostructure=self.heterostructure)
 
         self.potcar_pspfiles = pspfiles
 


### PR DESCRIPTION
This update allows the repeating order in atoms in POSCAR to be conserved. 

For example:

Sr V O
1.0
   3.8465199999999999   0.0000000000000000   0.0000000000000000
   0.0000000000000000   3.8465199999999999   0.0000000000000000
   0.0000000000000000   0.0000000000000000   3.8465199999999999
 **Sr V Sr O
 1 1 1 3**
Direct
   0.0000000000000000   0.0000000000000000   0.0000000000000000
   0.5000000000000000   0.5000000000000000   0.5000000000000000
   0.5000000000000000   0.5000000000000000   0.0000000000000000
   0.5000000000000000   0.0000000000000000   0.5000000000000000
   0.5000000000000000   0.5000000000000000   0.0000000000000000
   0.0000000000000000   0.5000000000000000   0.5000000000000000

Here the order Sr, V, Sr, O will be conserved when using the structure to generate POTCARs and POSCARs for kgrid, encut convergence and relaxation with PyChemia. Otherwise, it reverts to Sr, V, O ignoring the order of the repetition. 

This is helpful for performing calculations for heterostructures where atoms in layers are ordered separately. The order of the POTCAR concatenation will follow this too. 

-Uthpala