### PR TITLE
Removed pyximport from lennardjones since it only works if cython is installed.

### DIFF
--- a/pychemia/code/lennardjones/__init__.py
+++ b/pychemia/code/lennardjones/__init__.py
@@ -2,8 +2,8 @@
 Includes class LennardJones and several methods to relax and compute forces and energies from Lennard-Jones clusters
 
 """
-import pyximport
-pyximport.install()
+# import pyximport
+# pyximport.install()
 
 from .lj import LennardJones, lj_compact_evaluate
 from .lj_utils import lj_energy, lj_forces, lj_gradient

--- a/pychemia/code/lennardjones/lj.py
+++ b/pychemia/code/lennardjones/lj.py
@@ -1,5 +1,5 @@
-import pyximport
-pyximport.install()
+# import pyximport
+# pyximport.install()
 
 import numpy as np
 import scipy.optimize


### PR DESCRIPTION
Dear Guillermo,

Since setup.py already compiles the shared library required for lennardjones utilities for both cython and non-cython, this is unnecessary. It would be useful in the case that the shared library is not compiled and the import from the .pyx file needed to be imported directly without any compilation whatsoever. 

With the current setup.py, keeping the .pyx and .c in the distribution package will make sure it will work when both cython is present and not present. 

Best,
Uthpala