### PR TITLE
updated relax.py to keep EDIFF provided by user and only use 1E-04 if not provided

### DIFF
--- a/pychemia/code/vasp/task/relax.py
+++ b/pychemia/code/vasp/task/relax.py
@@ -17,29 +17,49 @@ from ..vasp import VaspJob, VaspAnalyser
 from ...relaxator import Relaxator
 from ...tasks import Task
 
-__author__ = 'Guillermo Avendano-Franco'
+__author__ = "Guillermo Avendano-Franco"
 
 
 class IonRelaxation(Relaxator, Task):
-    def __init__(self, structure, workdir='.', target_forces=1E-3, executable='vasp',
-                 encut=1.3, kp_grid=None, kp_density=1E4, relax_cell=True,
-                 max_calls=10,pspdir='potpaw_PBE', psp_options=None, extra_vars=None, heterostructure=False):
+    def __init__(
+        self,
+        structure,
+        workdir=".",
+        target_forces=1e-3,
+        executable="vasp",
+        encut=1.3,
+        kp_grid=None,
+        kp_density=1e4,
+        relax_cell=True,
+        max_calls=10,
+        pspdir="potpaw_PBE",
+        psp_options=None,
+        extra_vars=None,
+        heterostructure=False,
+    ):
 
         Relaxator.__init__(self, target_forces)
         self.target_forces = target_forces
 
         # If heterostructure is true it will keep the repeating order found
-        # in the POSCAR. 
+        # in the POSCAR.
         # Added by Uthpala on Apr 20th, 2020.
-        self.heterostructure = heterostructure 
+        self.heterostructure = heterostructure
 
         self.vaspjob = VaspJob(executable=executable, workdir=workdir)
         self.relaxed = False
         if kp_grid is not None:
-            self.kpoints = KPoints(kmode='gamma', grid=kp_grid)
+            self.kpoints = KPoints(kmode="gamma", grid=kp_grid)
         else:
-            self.kpoints = KPoints.optimized_grid(structure.lattice, kp_density=kp_density)
-        self.vaspjob.initialize(structure=structure, kpoints=self.kpoints, pspdir=pspdir, heterostructure=self.heterostructure)
+            self.kpoints = KPoints.optimized_grid(
+                structure.lattice, kp_density=kp_density
+            )
+        self.vaspjob.initialize(
+            structure=structure,
+            kpoints=self.kpoints,
+            pspdir=pspdir,
+            heterostructure=self.heterostructure,
+        )
         self.vaspjob.potcar_setup = psp_options
         self.encut = encut
         self.relax_cell = relax_cell
@@ -50,11 +70,19 @@ class IonRelaxation(Relaxator, Task):
         else:
             self.extra_vars = {}
 
-        
-
-        task_params = {'target_forces': self.target_forces, 'encut': self.encut, 'relax_cell': self.relax_cell,
-                       'max_calls': self.max_calls}
-        Task.__init__(self, structure=structure, task_params=task_params, workdir=workdir, executable=executable)
+        task_params = {
+            "target_forces": self.target_forces,
+            "encut": self.encut,
+            "relax_cell": self.relax_cell,
+            "max_calls": self.max_calls,
+        }
+        Task.__init__(
+            self,
+            structure=structure,
+            task_params=task_params,
+            workdir=workdir,
+            executable=executable,
+        )
 
     def create_dirs(self, clean=False):
         if not os.path.isdir(self.workdir):
@@ -72,50 +100,55 @@ class IonRelaxation(Relaxator, Task):
         """
         vj = self.vaspjob
 
-        if os.path.isfile(self.workdir + os.sep + 'OUTCAR'):
+        if os.path.isfile(self.workdir + os.sep + "OUTCAR"):
             vj.get_outputs()
 
         max_force, max_stress = self.get_max_force_stress()
         if max_force is not None and max_stress is not None:
-            pcm_log.debug('Max Force: %9.3E Stress: %9.3E' % (max_force, max_stress))
-            vo = VaspOutput(self.workdir + os.sep + 'OUTCAR')
+            pcm_log.debug("Max Force: %9.3E Stress: %9.3E" % (max_force, max_stress))
+            vo = VaspOutput(self.workdir + os.sep + "OUTCAR")
             info = vo.relaxation_info()
-            pcm_log.debug('Avg Force: %9.3E Stress: %9.3E %9.3E' % (info['avg_force'],
-                                                                    info['avg_stress_diag'],
-                                                                    info['avg_stress_non_diag']))
+            pcm_log.debug(
+                "Avg Force: %9.3E Stress: %9.3E %9.3E"
+                % (
+                    info["avg_force"],
+                    info["avg_stress_diag"],
+                    info["avg_stress_non_diag"],
+                )
+            )
         else:
-            print('Failure to get forces and stress')
+            print("Failure to get forces and stress")
             return False
 
-        vo = VaspOutput(self.workdir + os.sep + 'OUTCAR')
+        vo = VaspOutput(self.workdir + os.sep + "OUTCAR")
         info = vo.relaxation_info()
         if len(info) != 3:
-            print(' Missing some data in OUTCAR (forces or stress)')
+            print(" Missing some data in OUTCAR (forces or stress)")
 
         # Conditions to consider the structure relaxed
-        if info['avg_force'] < self.target_forces:
-            if info['avg_stress_diag'] < self.target_forces:
-                if info['avg_stress_non_diag'] < self.target_forces:
-                    wf = open(self.workdir + os.sep + 'RELAXED', 'w')
+        if info["avg_force"] < self.target_forces:
+            if info["avg_stress_diag"] < self.target_forces:
+                if info["avg_stress_non_diag"] < self.target_forces:
+                    wf = open(self.workdir + os.sep + "RELAXED", "w")
                     for i in info:
                         wf.write("%15s %12.3f" % (i, info[i]))
                     wf.close()
-                    wf = open(self.workdir + os.sep + 'COMPLETE', 'w')
+                    wf = open(self.workdir + os.sep + "COMPLETE", "w")
                     for i in info:
                         wf.write("%15s %12.3f" % (i, info[i]))
                     wf.close()
 
         # How to change ISIF
-        if info['avg_force'] < 0.1 and self.relax_cell:
-            if info['avg_stress_diag'] < 0.1:
-                if info['avg_stress_non_diag'] < 0.1:
-                    vj.input_variables['ISIF'] = 3
+        if info["avg_force"] < 0.1 and self.relax_cell:
+            if info["avg_stress_diag"] < 0.1:
+                if info["avg_stress_non_diag"] < 0.1:
+                    vj.input_variables["ISIF"] = 3
                 else:
-                    vj.input_variables['ISIF'] = 3
+                    vj.input_variables["ISIF"] = 3
             else:
-                vj.input_variables['ISIF'] = 3
+                vj.input_variables["ISIF"] = 3
         else:
-            vj.input_variables['ISIF'] = 2
+            vj.input_variables["ISIF"] = 2
 
         # How to change IBRION
         # if info['avg_force'] < 0.1 and info['avg_stress_diag'] < 0.1 and info['avg_stress_non_diag'] < 0.1:
@@ -134,44 +167,62 @@ class IonRelaxation(Relaxator, Task):
         # How to change EDIFFG
         if max_force > self.target_forces or max_stress > self.target_forces:
             if self.relax_cell:
-                vj.input_variables['EDIFFG'] = min(round_small(-0.01 * max(max_force, max_stress)),
-                                                       -self.target_forces)
+                vj.input_variables["EDIFFG"] = min(
+                    round_small(-0.01 * max(max_force, max_stress)), -self.target_forces
+                )
             else:
-                vj.input_variables['EDIFFG'] = min(round_small(-0.01 * max_force), -self.target_forces)
+                vj.input_variables["EDIFFG"] = min(
+                    round_small(-0.01 * max_force), -self.target_forces
+                )
 
-        pcm_log.debug('Current Values: ISIF: %2d   IBRION: %2d   EDIFF: %7.1E \tEDIFFG: %7.1E' %
-                      (vj.input_variables['ISIF'],
-                       vj.input_variables['IBRION'],
-                       vj.input_variables['EDIFF'],
-                       vj.input_variables['EDIFFG']))
+        pcm_log.debug(
+            "Current Values: ISIF: %2d   IBRION: %2d   EDIFF: %7.1E \tEDIFFG: %7.1E"
+            % (
+                vj.input_variables["ISIF"],
+                vj.input_variables["IBRION"],
+                vj.input_variables["EDIFF"],
+                vj.input_variables["EDIFFG"],
+            )
+        )
 
         # How to change EDIFF
-        if vj.input_variables['EDIFF'] > -0.01 * vj.input_variables['EDIFFG']:
-            vj.input_variables['EDIFF'] = round_small(-0.01 * vj.input_variables['EDIFFG'])
+        if vj.input_variables["EDIFF"] > -0.01 * vj.input_variables["EDIFFG"]:
+            vj.input_variables["EDIFF"] = round_small(
+                -0.01 * vj.input_variables["EDIFFG"]
+            )
         else:
-            vj.input_variables['EDIFF'] = 1E-4
+            if self.extra_vars["EDIFF"]:
+                vj.input_variables["EDIFF"] = self.extra_vars["EDIFF"]
+            else:
+                vj.input_variables["EDIFF"] = 1e-4
 
-        vj.input_variables['LWAVE'] = False
+        vj.input_variables["LWAVE"] = False
 
         # Print new values
-        pcm_log.debug('New Values: ISIF: %2d   IBRION: %2d   EDIFF: %7.1E \tEDIFFG: %7.1E' %
-                      (vj.input_variables['ISIF'],
-                       vj.input_variables['IBRION'],
-                       vj.input_variables['EDIFF'],
-                       vj.input_variables['EDIFFG']))
+        pcm_log.debug(
+            "New Values: ISIF: %2d   IBRION: %2d   EDIFF: %7.1E \tEDIFFG: %7.1E"
+            % (
+                vj.input_variables["ISIF"],
+                vj.input_variables["IBRION"],
+                vj.input_variables["EDIFF"],
+                vj.input_variables["EDIFFG"],
+            )
+        )
 
-        for i in ['POSCAR', 'INCAR', 'OUTCAR', 'vasprun.xml']:
+        for i in ["POSCAR", "INCAR", "OUTCAR", "vasprun.xml"]:
             if not os.path.exists(self.workdir + os.sep + i):
-                wf = open(self.workdir + os.sep + i, 'w')
-                wf.write('')
+                wf = open(self.workdir + os.sep + i, "w")
+                wf.write("")
                 wf.close()
-            log = logging.handlers.RotatingFileHandler(self.workdir + os.sep + i, maxBytes=1, backupCount=1000)
+            log = logging.handlers.RotatingFileHandler(
+                self.workdir + os.sep + i, maxBytes=1, backupCount=1000
+            )
             log.doRollover()
 
         vj.structure = self.get_final_geometry()
 
         vj.set_inputs()
-        vj.save_json(self.workdir + os.sep + 'vaspjob.json')
+        vj.save_json(self.workdir + os.sep + "vaspjob.json")
         return True
 
     def first_run(self, nparal=4, waiting=True):
@@ -181,24 +232,30 @@ class IonRelaxation(Relaxator, Task):
         inp = VaspInput()
         inp.set_rough_relaxation()
         vj.set_input_variables(inp)
-        vj.input_variables['LWAVE'] = False
+        vj.input_variables["LWAVE"] = False
         vj.write_potcar()
-        vj.input_variables.set_encut(ENCUT=self.encut, POTCAR=self.workdir + os.sep + 'POTCAR')
+        vj.input_variables.set_encut(
+            ENCUT=self.encut, POTCAR=self.workdir + os.sep + "POTCAR"
+        )
         vj.input_variables.set_density_for_restart()
 
         for i in self.extra_vars:
-            vj.input_variables[i]=self.extra_vars[i]
+            vj.input_variables[i] = self.extra_vars[i]
 
         vj.set_kpoints(self.kpoints)
         vj.set_inputs()
-        print('Launching VASP using %d processes' % nparal)
+        print("Launching VASP using %d processes" % nparal)
         vj.run(mpi_num_procs=nparal, wait=waiting)
 
     def cleaner(self):
 
-        files = [x for x in os.listdir(self.workdir) if os.path.isfile(self.workdir + os.sep + x)]
+        files = [
+            x
+            for x in os.listdir(self.workdir)
+            if os.path.isfile(self.workdir + os.sep + x)
+        ]
         for i in files:
-            if i[:5] in ['INCAR', 'POSCA', 'OUTCA', 'vaspr']:
+            if i[:5] in ["INCAR", "POSCA", "OUTCA", "vaspr"]:
                 os.remove(self.workdir + os.sep + i)
 
     def run(self, nparal=1, waiting=True):
@@ -211,9 +268,11 @@ class IonRelaxation(Relaxator, Task):
 
         while True:
             if vj.runner is not None and vj.runner.poll() is not None:
-                pcm_log.info('Execution completed. Return code %d' % vj.runner.returncode)
+                pcm_log.info(
+                    "Execution completed. Return code %d" % vj.runner.returncode
+                )
 
-                filename = self.workdir + os.sep + 'vasp_stdout.log'
+                filename = self.workdir + os.sep + "vasp_stdout.log"
                 if os.path.exists(filename):
                     read_vasp_stdout(filename=filename)
 
@@ -222,8 +281,10 @@ class IonRelaxation(Relaxator, Task):
                 va.run()
 
                 max_force, max_stress = self.get_max_force_stress()
-                print('Max Force: %9.3E Stress: %9.3E (target forces= %E)' %
-                      (max_force, max_stress, self.target_forces))
+                print(
+                    "Max Force: %9.3E Stress: %9.3E (target forces= %E)"
+                    % (max_force, max_stress, self.target_forces)
+                )
 
                 if max_force is not None and max_force < self.target_forces:
 
@@ -244,11 +305,17 @@ class IonRelaxation(Relaxator, Task):
                 if waiting:
                     vj.runner.wait()
             else:
-                filename = self.workdir + os.sep + 'vasp_stdout.log'
+                filename = self.workdir + os.sep + "vasp_stdout.log"
                 if os.path.exists(filename):
                     vasp_stdout = read_vasp_stdout(filename=filename)
-                    if len(vasp_stdout['iterations']) > 0:
-                        pcm_log.debug('[%s] SCF: %s' % (os.path.basename(self.workdir), str(vasp_stdout['iterations'])))
+                    if len(vasp_stdout["iterations"]) > 0:
+                        pcm_log.debug(
+                            "[%s] SCF: %s"
+                            % (
+                                os.path.basename(self.workdir),
+                                str(vasp_stdout["iterations"]),
+                            )
+                        )
                         # if len(vasp_stdout['energies']) > 2:
                         #     energy_str = ' %9.3E' % vasp_stdout['energies'][0]
                         #     for i in range(1, len(vasp_stdout['energies'])):
@@ -260,7 +327,9 @@ class IonRelaxation(Relaxator, Task):
 
                 time.sleep(30)
 
-        outcars = sorted([x for x in os.listdir(self.workdir) if x.startswith('OUTCAR')])[::-1]
+        outcars = sorted(
+            [x for x in os.listdir(self.workdir) if x.startswith("OUTCAR")]
+        )[::-1]
         vo = VaspOutput(self.workdir + os.sep + outcars[0])
         forces = vo.forces
         stress = vo.stress
@@ -271,20 +340,24 @@ class IonRelaxation(Relaxator, Task):
                 stress = np.concatenate((stress, vo.stress))
 
         vj.get_outputs()
-        self.output = {'forces': generic_serializer(forces), 'stress': generic_serializer(stress),
-                       'energy': vj.outcar.energy, 'energies': generic_serializer(vj.outcar.energies)}
+        self.output = {
+            "forces": generic_serializer(forces),
+            "stress": generic_serializer(stress),
+            "energy": vj.outcar.energy,
+            "energies": generic_serializer(vj.outcar.energies),
+        }
         if vj.outcar.is_finished:
             self.finished = True
 
     def get_forces_stress_energy(self):
 
-        filename = self.workdir + os.sep + 'OUTCAR'
+        filename = self.workdir + os.sep + "OUTCAR"
         if os.path.isfile(filename):
             self.vaspjob.get_outputs()
             if self.vaspjob.outcar.has_forces_stress_energy():
                 forces = self.vaspjob.outcar.forces[-1]
                 stress = self.vaspjob.outcar.stress[-1]
-                total_energy = self.vaspjob.outcar.final_data['energy']['free_energy']
+                total_energy = self.vaspjob.outcar.final_data["energy"]["free_energy"]
             else:
                 forces = None
                 stress = None
@@ -297,77 +370,87 @@ class IonRelaxation(Relaxator, Task):
 
     def get_final_geometry(self):
 
-        filename = self.workdir + os.sep + 'CONTCAR'
+        filename = self.workdir + os.sep + "CONTCAR"
         structure = None
         if os.path.isfile(filename):
             try:
                 structure = read_poscar(filename)
             except ValueError:
-                print('Error reading CONTCAR')
+                print("Error reading CONTCAR")
         return structure
 
-    def plot(self, filedir=None, file_format='pdf'):
+    def plot(self, filedir=None, file_format="pdf"):
         if filedir is None:
             filedir = self.workdir
         import matplotlib.pyplot as plt
-        plt.switch_backend('agg')
+
+        plt.switch_backend("agg")
 
         plt.figure(figsize=(8, 6))
-        plt.subplots_adjust(left=0.1, bottom=0.08, right=0.95, top=0.95, wspace=None, hspace=None)
-        forces = np.array(self.output['forces'])
+        plt.subplots_adjust(
+            left=0.1, bottom=0.08, right=0.95, top=0.95, wspace=None, hspace=None
+        )
+        forces = np.array(self.output["forces"])
         maxforce = [np.max(np.apply_along_axis(np.linalg.norm, 1, x)) for x in forces]
         avgforce = [np.mean(np.apply_along_axis(np.linalg.norm, 1, x)) for x in forces]
 
         if np.max(maxforce) > 0.0 and np.max(avgforce) > 0.0:
-            plt.semilogy(maxforce, 'b.-', label='Max force')
-            plt.semilogy(avgforce, 'r.-', label='Mean force')
+            plt.semilogy(maxforce, "b.-", label="Max force")
+            plt.semilogy(avgforce, "r.-", label="Mean force")
         else:
-            plt.plot(maxforce, 'b.-', label='Max force')
-            plt.plot(avgforce, 'r.-', label='Mean force')
-        plt.xlabel('Ion movement iteration')
-        plt.ylabel('Max Force')
-        plt.savefig(filedir + os.sep + 'forces.' + file_format)
+            plt.plot(maxforce, "b.-", label="Max force")
+            plt.plot(avgforce, "r.-", label="Mean force")
+        plt.xlabel("Ion movement iteration")
+        plt.ylabel("Max Force")
+        plt.savefig(filedir + os.sep + "forces." + file_format)
         plt.clf()
 
         plt.figure(figsize=(8, 6))
-        plt.subplots_adjust(left=0.1, bottom=0.08, right=0.95, top=0.95, wspace=None, hspace=None)
-        stress = np.array(self.output['stress'])
+        plt.subplots_adjust(
+            left=0.1, bottom=0.08, right=0.95, top=0.95, wspace=None, hspace=None
+        )
+        stress = np.array(self.output["stress"])
         diag_stress = [np.trace(np.abs(x)) for x in stress]
         offdiag_stress = [np.sum(np.abs(np.triu(x, 1).flatten())) for x in stress]
-        plt.semilogy(diag_stress, 'b.-', label='diagonal')
-        plt.semilogy(offdiag_stress, 'r.-', label='off-diagonal')
+        plt.semilogy(diag_stress, "b.-", label="diagonal")
+        plt.semilogy(offdiag_stress, "r.-", label="off-diagonal")
         plt.legend()
-        plt.xlabel('Ion movement iteration')
-        plt.ylabel(r'$\sum |stress|$ (diag, off-diag)')
-        plt.savefig(filedir + os.sep + 'stress.' + file_format)
+        plt.xlabel("Ion movement iteration")
+        plt.ylabel(r"$\sum |stress|$ (diag, off-diag)")
+        plt.savefig(filedir + os.sep + "stress." + file_format)
 
-    def report(self, file_format='html'):
+    def report(self, file_format="html"):
         from lxml.builder import ElementMaker, E
 
-        self.plot(filedir=self.report_dir, file_format='jpg')
+        self.plot(filedir=self.report_dir, file_format="jpg")
 
-        element_maker = ElementMaker(namespace=None, nsmap={None: "http://www.w3.org/1999/xhtml"})
-        html = element_maker.html(E.head(E.title("VASP Ion Relaxation")),
-                                  E.body(E.h1("VASP Ion Relaxation"),
-                                         E.h2('Initial Structure'),
-                                         E.pre(str(self.structure)),
-                                         E.h2('Forces Minimization'),
-                                         E.p(E.img(src='forces.jpg', width="800", height="600", alt="Forces")),
-                                         E.h2('Stress Minimization'),
-                                         E.p(E.img(src='stress.jpg', width="800", height="600", alt="Stress"))
-                                         ))
+        element_maker = ElementMaker(
+            namespace=None, nsmap={None: "http://www.w3.org/1999/xhtml"}
+        )
+        html = element_maker.html(
+            E.head(E.title("VASP Ion Relaxation")),
+            E.body(
+                E.h1("VASP Ion Relaxation"),
+                E.h2("Initial Structure"),
+                E.pre(str(self.structure)),
+                E.h2("Forces Minimization"),
+                E.p(E.img(src="forces.jpg", width="800", height="600", alt="Forces")),
+                E.h2("Stress Minimization"),
+                E.p(E.img(src="stress.jpg", width="800", height="600", alt="Stress")),
+            ),
+        )
 
         return self.report_end(html, file_format)
 
     def load(self, filename=None):
         if filename is None:
-            filename = self.workdir + os.sep + 'task.json'
+            filename = self.workdir + os.sep + "task.json"
         rf = open(filename)
         data = json.load(rf)
         rf.close()
-        self.task_params = data['task_params']
-        self.output = data['output']
-        self.encut = self.task_params['encut']
-        self.target_forces = self.task_params['target_forces']
-        self.relax_cell = self.task_params['relax_cell']
-        self.max_calls = self.task_params['max_calls']
+        self.task_params = data["task_params"]
+        self.output = data["output"]
+        self.encut = self.task_params["encut"]
+        self.target_forces = self.task_params["target_forces"]
+        self.relax_cell = self.task_params["relax_cell"]
+        self.max_calls = self.task_params["max_calls"]

--- a/setup.py
+++ b/setup.py
@@ -20,20 +20,20 @@ def git_version():
     def _minimal_ext_cmd(cmd):
         # construct minimal environment
         env = {}
-        for k in ['SYSTEMROOT', 'PATH']:
+        for k in ["SYSTEMROOT", "PATH"]:
             v = os.environ.get(k)
             if v is not None:
                 env[k] = v
         # LANGUAGE is used on win32
-        env['LANGUAGE'] = 'C'
-        env['LANG'] = 'C'
-        env['LC_ALL'] = 'C'
+        env["LANGUAGE"] = "C"
+        env["LANG"] = "C"
+        env["LC_ALL"] = "C"
         out = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env).communicate()[0]
         return out
 
     try:
-        out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
-        GIT_REVISION = out.strip().decode('ascii')
+        out = _minimal_ext_cmd(["git", "rev-parse", "HEAD"])
+        GIT_REVISION = out.strip().decode("ascii")
     except OSError:
         GIT_REVISION = "Unknown"
 
@@ -45,33 +45,34 @@ def get_version_info():
     # write_version_py(), otherwise the import of scipy.version messes
     # up the build under Python 3.
 
-    basepath=pathlib.Path(__file__).parent.absolute()
+    basepath = pathlib.Path(__file__).parent.absolute()
     print(basepath)
 
-    rf = open(str(basepath)+os.sep+'setup.json')
+    rf = open(str(basepath) + os.sep + "setup.json")
     release_data = json.load(rf)
     rf.close()
 
-    FULLVERSION = release_data['version']
+    FULLVERSION = release_data["version"]
 
-    if os.path.exists('.git'):
+    if os.path.exists(".git"):
         GIT_REVISION = git_version()
-    elif os.path.exists('scipy/version.py'):
+    elif os.path.exists("scipy/version.py"):
         # must be a source distribution, use existing version file
         # load it as a separate module to not load scipy/__init__.py
         import runpy
-        ns = runpy.run_path('pychemia/version.py')
-        GIT_REVISION = ns['git_revision']
+
+        ns = runpy.run_path("pychemia/version.py")
+        GIT_REVISION = ns["git_revision"]
     else:
         GIT_REVISION = "Unknown"
 
     if not ISRELEASED:
-        FULLVERSION += '.dev0+' + GIT_REVISION[:7]
+        FULLVERSION += ".dev0+" + GIT_REVISION[:7]
 
     return release_data, FULLVERSION, GIT_REVISION
 
 
-def write_version_py(filename='pychemia/version.py'):
+def write_version_py(filename="pychemia/version.py"):
     cnt = """
 # THIS FILE IS GENERATED FROM PYCHEMIA SETUP.PY
 short_version = '%(version)s'
@@ -92,33 +93,46 @@ if not release:
 """
     release_data, FULLVERSION, GIT_REVISION = get_version_info()
 
-    a = open(filename, 'w')
+    a = open(filename, "w")
     try:
-        a.write(cnt % {'version': release_data['version'],
-                       'full_version': FULLVERSION,
-                       'git_revision': GIT_REVISION,
-                       'name': release_data['name'],
-                       'description': release_data['description'],
-                       'url': release_data['url'],
-                       'author': release_data['author'],
-                       'email': release_data['email'],
-                       'status': release_data['status'],
-                       'copyright': release_data['copyright'],
-                       'date': release_data['date'],
-                       'isrelease': str(ISRELEASED)})
+        a.write(
+            cnt
+            % {
+                "version": release_data["version"],
+                "full_version": FULLVERSION,
+                "git_revision": GIT_REVISION,
+                "name": release_data["name"],
+                "description": release_data["description"],
+                "url": release_data["url"],
+                "author": release_data["author"],
+                "email": release_data["email"],
+                "status": release_data["status"],
+                "copyright": release_data["copyright"],
+                "date": release_data["date"],
+                "isrelease": str(ISRELEASED),
+            }
+        )
     finally:
         a.close()
     return release_data
 
 
 def get_scripts():
-    return ['scripts' + os.sep + x for x in os.listdir('scripts') if x[-3:] == '.py']
+    return ["scripts" + os.sep + x for x in os.listdir("scripts") if x[-3:] == ".py"]
+
 
 ###################################################################
 
 ISRELEASED = False
 
-KEYWORDS = ["electronic", "structure", "analysis", "materials", "discovery", "metaheuristics"]
+KEYWORDS = [
+    "electronic",
+    "structure",
+    "analysis",
+    "materials",
+    "discovery",
+    "metaheuristics",
+]
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
@@ -132,58 +146,78 @@ CLASSIFIERS = [
     "Topic :: Scientific/Engineering :: Chemistry",
     "Topic :: Scientific/Engineering :: Physics",
 ]
-INSTALL_REQUIRES = ['numpy >= 1.17',
-                    'scipy >= 1.3',
-                    'spglib >= 1.9',
-                    'pymongo >= 3.9',
-                    'matplotlib >= 3.0',
-                    'psutil >= 5.6']
+INSTALL_REQUIRES = [
+    "numpy >= 1.17",
+    "scipy >= 1.3",
+    "spglib >= 1.9",
+    "pymongo >= 3.9",
+    "matplotlib >= 3.0",
+    "psutil >= 5.6",
+]
 
 ###################################################################
 
-print('Using Cython: %s' % USE_CYTHON)
+print("Using Cython: %s" % USE_CYTHON)
 data = write_version_py()
 
 cmdclass = {}
-ext = '.pyx' if USE_CYTHON else '.c'
+ext = ".pyx" if USE_CYTHON else ".c"
+
 
 class sdist(_sdist):
     def run(self):
-            # Make sure the compiled Cython files in the distribution are
-            # up-to-date
-            from Cython.Build import cythonize
-            cythonize(ext_modules, annotate=True, compiler_directives={'embedsignature': True})
-            _sdist.run(self)
+        # Make sure the compiled Cython files in the distribution are
+        # up-to-date
+        from Cython.Build import cythonize
 
-cmdclass['sdist'] = sdist
+        cythonize(
+            ext_modules, annotate=True, compiler_directives={"embedsignature": True}
+        )
+        _sdist.run(self)
 
-ext_modules = [Extension("pychemia.code.lennardjones.lj_utils", ['pychemia/code/lennardjones/lj_utils' + ext])]
+
+cmdclass["sdist"] = sdist
+
+ext_modules = [
+    Extension(
+        "pychemia.code.lennardjones.lj_utils",
+        ["pychemia/code/lennardjones/lj_utils" + ext],
+    )
+]
 
 if USE_CYTHON:
-    cmdclass.update({'build_ext': build_ext})
+    cmdclass.update({"build_ext": build_ext})
     from Cython.Build import cythonize
-    ext_modules = cythonize([Extension("pychemia.code.lennardjones.lj_utils", ['pychemia/code/lennardjones/lj_utils' + ext])])
+
+    ext_modules = cythonize(
+        [
+            Extension(
+                "pychemia.code.lennardjones.lj_utils",
+                ["pychemia/code/lennardjones/lj_utils" + ext],
+            )
+        ]
+    )
 
 
 setup(
-    name=data['name'],
-    version=data['version'],
-    author=data['author'],
-    author_email=data['email'],
-    packages=find_packages(exclude=['scripts', 'docs', 'tests']),
-    url=data['url'],
-    license='LICENSE.txt',
-    description=data['description'],
-    long_description=open('README').read(),
+    name=data["name"],
+    version=data["version"],
+    author=data["author"],
+    author_email=data["email"],
+    packages=find_packages(exclude=["scripts", "docs", "tests"]),
+    url=data["url"],
+    license="LICENSE.txt",
+    description=data["description"],
+    long_description=open("README").read(),
     install_requires=INSTALL_REQUIRES,
     keywords=KEYWORDS,
     classifiers=CLASSIFIERS,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4',
-    package_data={'': ['setup.json']},
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4",
+    package_data={"": ["setup.json"]},
     scripts=get_scripts(),
     cmdclass=cmdclass,
     ext_modules=ext_modules
-#    ext_modules=cythonize(ext_modules, annotate=True, compiler_directives={'embedsignature': True})
+    #    ext_modules=cythonize(ext_modules, annotate=True, compiler_directives={'embedsignature': True})
 )
 
 # ext_modules=cythonize(Extension('pychemia.code.lennardjones.hello',


### PR DESCRIPTION
Hello Guillermo, 

In some of my structural relaxation I wanted to keep a lower EDIFF value so I added this in relax.py to use the EDIFF provided by the user in the INCAR. If not provided it will use the default value of EDIFF=1E-04. 

I simply changed:

`        # How to change EDIFF
        if vj.input_variables["EDIFF"] > -0.01 * vj.input_variables["EDIFFG"]:
            vj.input_variables["EDIFF"] = round_small(
                -0.01 * vj.input_variables["EDIFFG"]
            )
        else:
                vj.input_variables["EDIFF"] = 1e-4`

to 

`
        # How to change EDIFF
        if vj.input_variables["EDIFF"] > -0.01 * vj.input_variables["EDIFFG"]:
            vj.input_variables["EDIFF"] = round_small(
                -0.01 * vj.input_variables["EDIFFG"]
            )
        else:
            if self.extra_vars["EDIFF"]:
                vj.input_variables["EDIFF"] = self.extra_vars["EDIFF"]
            else:
                vj.input_variables["EDIFF"] = 1e-4
`

If you think it's something that is useful please merge it and add it to pip. 

Thank you, 

Best,
Uthpala